### PR TITLE
Build just once weekly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: ci/cd
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 9 * * 1,3' # runs workflow every Monday and Wednesday at 9:30 UTC.
+    - cron: '30 9 * * 1' # runs workflow every Monday and Wednesday at 9:30 UTC.
   pull_request:
 
 jobs:


### PR DESCRIPTION
Reduce impact on actions billing by reducing full-scale infra build to once a week. This is enough to maintain security patching for low, moderate and high priority vulnerabilities in a reasonable timescale. Critical patching will be done manually based on CVE alerting.

Also weekly is enough to maintain high resolution of the decay of software dependencies out in the wild, especially in python.