### PR TITLE
Update base image version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with JupyterHub image.
-FROM quay.io/jupyter/base-notebook:2026-03-16
+FROM quay.io/jupyter/base-notebook:hub-5.4.3
 
 LABEL maintainer="James Gebbie-Rayet <james.gebbie@stfc.ac.uk>"
 LABEL org.opencontainers.image.source=https://github.com/ccpbiosim/jupyterhub-base


### PR DESCRIPTION
Change to the app version since the dated builds would allow the app to update silently which poses additional problems to the app tag which allows the build to update with their CI on the tag. If this ends up problematic then change to known working SHA 31443e4237a3 at minimum