### PR TITLE
Fix Matomo tracking URL format

### DIFF
--- a/matomo-js.txt
+++ b/matomo-js.txt
@@ -27,7 +27,7 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
 
-    var u = "https://matomo.ccpbiosim.org";
+    var u = "https://matomo.ccpbiosim.org/";
     _paq.push(['setTrackerUrl', u + 'matomo.php']);
     _paq.push(['setSiteId', '1']);
 


### PR DESCRIPTION
Missing a slash causing stats to go missing